### PR TITLE
add function tu parse vunerabilities to JSON

### DIFF
--- a/packages/sdk/src/utils.js
+++ b/packages/sdk/src/utils.js
@@ -96,7 +96,7 @@ function processVulnerabilityReport(inputFilePath, outputDirectory) {
       const type = fixedIn ? parts[3] : parts[2];
       const vulnerability = fixedIn ? parts[4] : parts[3];
       const rawSeverity = fixedIn ? parts[5] : parts[4];
-      const validSeverities = ['Medium', 'High', 'Critical', 'Low'];
+      const validSeverities = ['Medium', 'High', 'Critical', 'Low', 'Negligible'];
       const severity = validSeverities.includes(rawSeverity) ? rawSeverity : 'Unknown';
       const sanitizedFileName = name.replace(/[^a-zA-Z0-9-_]/g, '_');
 


### PR DESCRIPTION
The functions takes a vulnerability file produced by sbom-gap tool and an output directory path.
The JSON file is saved as `packageName_number.JSON` - there may be more packages with the same name, so I've added an index number.

I have covered the following edge ceases ( there may be more :)  ):
### FIXED-IN missing
`base         1.24.6                            UnknownPackage  CVE-2014-2980   Medium  `

```JSON
{
    "base": {
        "installed": "1.24.6",
        "fixed-in": null,
        "type": "UnknownPackage",
        "vulnerability": "CVE-2014-2980",
        "severity": "Medium"
    }
}
```

### Multiple FIXED-IN versions
`nanopb       0.4.4       0.3.9.8, 0.4.5  UnknownPackage  CVE-2021-21401  High `

```JSON
{
    "nanopb": {
        "installed": "0.4.4",
        "fixed-in": [
            "0.3.9.8",
            "0.4.5"
        ],
        "type": "UnknownPackage",
        "vulnerability": "CVE-2021-21401",
        "severity": "High"
    }
}
```
### Special characters in name
`@babel/traverse   7.14.2     7.23.2    npm    GHSA-67hx-6x53-jw92  Critical  `

```JSON
{
    "@babel/traverse": {
        "installed": "7.14.2",
        "fixed-in": [
            "7.23.2"
        ],
        "type": "npm",
        "vulnerability": "GHSA-67hx-6x53-jw92",
        "severity": "Critical"
    }
}
```

### Installed version missing
`oneapi       -           4.3.2           UnknownPackage  CVE-2023-32618  High `

```JSON
{
    "oneapi": {
        "installed": null,
        "fixed-in": [
            "4.3.2"
        ],
        "type": "UnknownPackage",
        "vulnerability": "CVE-2023-32618",
        "severity": "High"
    }
}
```

### Both insatalled and fixed-in missing
`oneapi       -                           UnknownPackage  CVE-2021-45046  Critical`

```JSON
{
    "oneapi": {
        "installed": null,
        "fixed-in": null,
        "type": "UnknownPackage",
        "vulnerability": "CVE-2021-45046",
        "severity": "Critical"
    }
}
```

### (won't fix as placement for FIXED-IN)
`coreutils           9.1-1                    (won't fix)       deb   CVE-2016-2781     Low `

```JSON
{
    "coreutils": {
        "installed": "9.1-1",
        "fixed-in": [
            "(won't fix)"
        ],
        "type": "deb",
        "vulnerability": "CVE-2016-2781",
        "severity": "Low"
    }
}
```

