### PR TITLE
Fix for claim cascade handling ids

### DIFF
--- a/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-447d1ddd-edf2-4ac8-b0c2-0a14a86541ad.json
+++ b/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-447d1ddd-edf2-4ac8-b0c2-0a14a86541ad.json
@@ -15,7 +15,6 @@
     "type": "JsonSchema"
   },
   "credentialSubject": {
-    "id": "urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad",
     "hash": "0ea4133d796cf4c6c444d7ca1a94343798fc974c1fcca9cf168345b02a526a51",
     "label": "Training",
     "lastAccessed": "2024-12-16T13:26:30.868Z",

--- a/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-5f6dc5e9-002e-4ec9-80c4-cae7e1940c6c.json
+++ b/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-5f6dc5e9-002e-4ec9-80c4-cae7e1940c6c.json
@@ -15,7 +15,6 @@
     "type": "JsonSchema"
   },
   "credentialSubject": {
-    "id": "urn:uuid:5f6dc5e9-002e-4ec9-80c4-cae7e1940c6c",
     "hash": "9cb2cfd169166958a6f036eeb554fc72c4df43417b4d7a84e2a06a80eb4e0f97",
     "label": "Training",
     "lastAccessed": "2024-12-16T13:26:40.966Z",

--- a/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-7b88099f-f6f6-4dc4-b0e0-d201b89b5e74.json
+++ b/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-7b88099f-f6f6-4dc4-b0e0-d201b89b5e74.json
@@ -15,7 +15,6 @@
     "type": "JsonSchema"
   },
   "credentialSubject": {
-    "id": "urn:uuid:7b88099f-f6f6-4dc4-b0e0-d201b89b5e74",
     "hash": "2fe24dae2b47899e5b33922702b3eb30e8c217d61b64128b7094f6485a1cce3d",
     "label": "Training",
     "lastAccessed": "2024-12-16T13:26:32.860Z",

--- a/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-87af45cd-27a8-4815-9b26-1f0de5a43ced.json
+++ b/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-87af45cd-27a8-4815-9b26-1f0de5a43ced.json
@@ -15,7 +15,6 @@
     "type": "JsonSchema"
   },
   "credentialSubject": {
-    "id": "urn:uuid:87af45cd-27a8-4815-9b26-1f0de5a43ced",
     "hash": "156a17c84d424c0649d574e60ef8106b06761da44efbfb918e08e5336cc98ee0",
     "label": "Training",
     "lastAccessed": "2024-12-16T13:26:27.804Z",

--- a/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-9dc8a381-9a7d-4a2f-aa68-5a804e7a5d01.json
+++ b/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-9dc8a381-9a7d-4a2f-aa68-5a804e7a5d01.json
@@ -15,7 +15,6 @@
     "type": "JsonSchema"
   },
   "credentialSubject": {
-    "id": "urn:uuid:9dc8a381-9a7d-4a2f-aa68-5a804e7a5d01",
     "hash": "8024d0b6f45b7547e1aae4511887520594c6038bf7d89bc44f154f2002a75b04",
     "label": "Weights",
     "lastAccessed": "2024-12-16T13:32:43.303Z",

--- a/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-dddce76c-a0a0-448b-a849-0a9b1999601b.json
+++ b/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/ETS2SignDetection-release-4-pack/TAIBOM-data-dddce76c-a0a0-448b-a849-0a9b1999601b.json
@@ -15,7 +15,6 @@
     "type": "JsonSchema"
   },
   "credentialSubject": {
-    "id": "urn:uuid:dddce76c-a0a0-448b-a849-0a9b1999601b",
     "hash": "a335083401e68ae86ef8c7382d6bb82ee143eb9b239b6994299e596cb2543539",
     "label": "Training",
     "lastAccessed": "2024-12-16T13:26:35.835Z",

--- a/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/schema.json
+++ b/packages/claim_cascade_batteries/taibom-battery/inference_claims/data/schema.json
@@ -32,10 +32,6 @@
     "context": "## Introduction\n\nThe **TAIBOM Data Schema** is a JSON schema designed to describe and standardise the metadata associated with datasets within the Trusted AI BOM (TAIBOM) ecosystem. This schema ensures datasets can be identified, located, and verified for integrity, enabling seamless and trustworthy AI operations.\n\n### Description\nThis schema captures essential metadata for datasets, including:\n- **Name**: A unique identifier for the dataset.\n- **Label**: Categorisation of the dataset (e.g., Training or Weights).\n- **Location**: Specifies where the dataset is stored, either locally or remotely, along with the respective path or URL.\n- **Hash**: A cryptographic hash (e.g., SHA256) for verifying the integrity of the dataset.\n- **Hash Location**: The location (local or remote) where the hash is stored.\n- **Last Accessed**: The timestamp of the last access to the dataset metadata.\n\n## Use Case\n\nThe **TAIBOM Data Schema** is primarily used within the TAIBOM framework to:\n1. **Enable Dataset Traceability**: Provide a clear and standardised format for referencing datasets and their locations.\n2. **Ensure Data Integrity**: Support integrity verification through cryptographic hashes and their associated storage locations.\n3. **Streamline Operations**: Offer metadata for efficient handling of datasets in AI workflows, whether stored locally or remotely.\n\nBy adopting this schema, organisations can standardise how datasets are documented, retrieved, and verified, ensuring robust data handling in AI systems.\n\n---\n",
     "description": "This schema describes the metadata of a dataset, including the location where it is hosted  (either locally or remotely) and where to resolve the hash for verifying data integrity.\n",
     "properties": {
-      "id": {
-        "type": "string",
-        "description": "id of the dataset"
-      },
       "hash": {
         "description": "The cryptographic hash (e.g., SHA256) of the dataset used for data integrity verification.",
         "type": "string"

--- a/packages/claim_cascade_batteries/taibom-battery/inference_claims/datapack/ETS2SignDetection-release-4-pack/TAIBOM-datapack-e7331e94-faac-457d-b842-322e064a42c6.json
+++ b/packages/claim_cascade_batteries/taibom-battery/inference_claims/datapack/ETS2SignDetection-release-4-pack/TAIBOM-datapack-e7331e94-faac-457d-b842-322e064a42c6.json
@@ -15,7 +15,6 @@
     "type": "JsonSchema"
   },
   "credentialSubject": {
-    "id": "urn:uuid:e7331e94-faac-457d-b842-322e064a42c6",
     "datasets": [
       {
         "hash": "u24U8GRf3VMZIkUJMiCfFqfMWHBwzdQ6WoOrrfBqaDev0nXYFsaGxZdOo3soTZJaQhTTB8tpRHxwF8udr99wCQ==",

--- a/packages/claim_cascade_batteries/taibom-battery/inference_claims/datapack/schema.json
+++ b/packages/claim_cascade_batteries/taibom-battery/inference_claims/datapack/schema.json
@@ -20,10 +20,6 @@
     "context": "## Introduction\n\nThe **TAIBOM Datapack Schema** is a JSON schema designed to describe and standardise collections of datasets within the Trusted AI BOM (TAIBOM) ecosystem. This schema ensures that groups of datasets, whether used for raw data, training, or testing, are organised and verified for integrity.\n\n### Description\nThis schema captures essential metadata for datapacks, including:\n- **Name**: A unique identifier for the datapack.\n- **Datasets**: A collection of dataset objects, each containing:\n  - A unique identifier (`id`) for traceability.\n  - A cryptographic hash (`hash`) to ensure data integrity.\n\n## Use Case\n\nThe **TAIBOM Datapack Schema** is primarily used within the TAIBOM framework to:\n1. **Organise Dataset Collections**: Provide a standardised format for grouping datasets used in AI workflows.\n2. **Enable Traceability**: Ensure that each dataset in the collection is uniquely identified and linked to its source.\n3. **Streamline Dataset Verification**: Facilitate verification and management of multiple datasets within a single datapack.\n\nBy adopting this schema, organisations can effectively manage and document groups of datasets, ensuring integrity and ease of use in AI system development and deployment.\n\n---\n",
     "description": "A datapack schema that describes a collection of datasets used for raw data, training data, and testing data.  Each collection has a unique identifier and a cryptographic hash for verifying data integrity.\n",
     "properties": {
-      "id": {
-        "type": "string",
-        "description": "id of the datapack"
-      },
       "datasets": {
         "description": "A list of dataset objects, each containing an ID and a cryptographic hash.\n",
         "items": {

--- a/packages/claim_cascade_batteries/taibom-battery/rules/ETS2SignDetection-release-4-pack/ai_systems_containing_data.json
+++ b/packages/claim_cascade_batteries/taibom-battery/rules/ETS2SignDetection-release-4-pack/ai_systems_containing_data.json
@@ -15,6 +15,6 @@
   },
   "credentialSubject": {
     "type": "rule",
-    "rule": "ai_systems_containing_data(DataId, AISystemName) :-\n    % Find the datapack containing the specific data item\n    db:get_taibom_data(_, _, _, DataId, _, _, _, _),\n    db:get_taibom_datapack(_, Datasets, DatapackId, _),\n    member(dataset(_, DataId), Datasets),\n    % Find the AI system linked to the datapack\n    get_ai_system(_, _, data(_, DatapackId), _, AISystemName)."
+    "rule": "ai_systems_containing_data(DataId, AISystemName) :-\n    % Find the datapack containing the specific data item\n    db:get_taibom_data(DataVcId, _, _, _, _, _, _),\n    db:get_taibom_datapack(DatapackVcId, Datasets, _),\n    member(dataset(_, DataVcId), Datasets),\n    % Find the AI system linked to the datapack\n    get_ai_system(_, _, data(_, DatapackVcId), _, AISystemName)."
   }
 }

--- a/packages/claim_cascade_batteries/taibom-battery/scenarios.json
+++ b/packages/claim_cascade_batteries/taibom-battery/scenarios.json
@@ -5,23 +5,23 @@
       "queries": [
         {
           "name": "Get all taibom data statements",
-          "query": "db:get_all_taibom_data(_, _, _, _, _, _, _, _, MatchingData)"
+          "query": "db:get_all_taibom_data( _, _, _, _, _, _, _, MatchingData)"
         },
         {
           "name": "Get all training data",
-          "query": "db:get_all_taibom_data(_, _, _, _, \"Training\", _, _, _, MatchingData)"
+          "query": "db:get_all_taibom_data(_, _, _, \"Training\", _, _, _, MatchingData)"
         },
         {
           "name": "Get all weights data",
-          "query": "db:get_all_taibom_data(_, _, _, _, \"Weights\", _, _, _, MatchingData)"
+          "query": "db:get_all_taibom_data(_, _, _, \"Weights\", _, _, _, MatchingData)"
         },
         {
           "name": "Get all datapacks containing data with id \"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\"",
-          "query": "db:get_taibom_data(_, _, _, \"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\", _, _, _, _),  db:get_taibom_datapack(_, _Datasets, Id, DatasetName), member(dataset(_, \"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\"), _Datasets)"
+          "query": "db:get_taibom_data(\"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\", _, _, _, _, _, _),  db:get_taibom_datapack(VcId, _Datasets, DatasetName), member(dataset(_, \"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\"), _Datasets)"
         },
         {
           "name": "Get all ai systems which rely on data with id \"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\"",
-          "query": "db:get_taibom_data(_, _, _, \"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\", _, _, _, _), db:get_taibom_datapack(_, _Datasets, _DatapackId, _), member(dataset(_, \"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\"), _Datasets), get_ai_system(_, _, data(_, _DatapackId), Label, Name)"
+          "query": "db:get_taibom_data(\"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\", _, _, _, _, _, _), db:get_taibom_datapack(_DatapackVcId_, _Datasets, _), member(dataset(_, \"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\"), _Datasets), get_ai_system(_, _, data(_, _DatapackVcId), Label, Name)"
         },
         {
           "name": "Use rule to get all ai systems which rely on data with id \"urn:uuid:447d1ddd-edf2-4ac8-b0c2-0a14a86541ad\"",


### PR DESCRIPTION
This now works with the most up-to-date version of claim cascade, and uses VC Ids instead of adding extra Ids to schemas.